### PR TITLE
Add dashboard links to patient names in emails

### DIFF
--- a/trbdv0/main.py
+++ b/trbdv0/main.py
@@ -72,6 +72,9 @@ def main():
     quatrics_config_path = config["quatrics_config_path"]
     quatrics_sleep_reminder = config["quatrics_sleep_reminder"]
     quatrics_nonwear_reminder = config["quatrics_nonwear_reminder"]
+    dashboard_base_url = config.get("dashboard_base_url") or os.environ.get(
+        "DASHBOARD_BASE_URL"
+    )
     timestamp = datetime.now(pytz.timezone(timezone))
     timestamp = timestamp.strftime("%Y-%m-%d_%H-%M-%S")
     today_date = get_todays_date()
@@ -341,7 +344,10 @@ def main():
 
     # send the main daily report email
     if all_patient_stats:
-        email_body = generate_email_body(all_patient_stats)
+        email_body = generate_email_body(
+            all_patient_stats,
+            dashboard_base_url=dashboard_base_url,
+        )
         subject = generate_subject_line(all_patient_stats)
         if args.subject_tag:
             subject = f"[{args.subject_tag}] {subject}"

--- a/trbdv0/send_email.py
+++ b/trbdv0/send_email.py
@@ -1,9 +1,12 @@
+import html
+import os
 import smtplib
 from email.message import EmailMessage
-from pathlib import Path
 from email.utils import make_msgid
+from pathlib import Path
 from typing import List, Optional
-import os
+from urllib.parse import urlencode
+
 import pandas as pd
 import numpy as np
 from trbdv0.utils import (
@@ -166,7 +169,48 @@ def generate_subject_line(all_patient_stats: list) -> str:
     return f"{study_name} [Warning: {flagged_str} need review]"
 
 
-def generate_email_body(all_patient_stats: list) -> str:
+def _dashboard_patient_url(dashboard_base_url: str | None, patient: str) -> str | None:
+    if not dashboard_base_url:
+        return None
+
+    base_url = dashboard_base_url.strip()
+    if not base_url:
+        return None
+
+    params = urlencode(
+        {
+            "mode": "clinical",
+            "project": "trbd",
+            "section": "index",
+            "environment": "chronic",
+            "patient": patient,
+            "tab": "clinical_scores",
+        }
+    )
+    separator = "&" if "?" in base_url else "?"
+    return f"{base_url}{separator}{params}"
+
+
+def _format_patient_label(
+    patient: str,
+    label: str,
+    dashboard_base_url: str | None,
+) -> str:
+    safe_label = html.escape(label)
+    url = _dashboard_patient_url(dashboard_base_url, patient)
+    if url is None:
+        return safe_label
+
+    return (
+        f'<a href="{html.escape(url, quote=True)}" '
+        f'style="color:#1C3079; text-decoration:underline;">{safe_label}</a>'
+    )
+
+
+def generate_email_body(
+    all_patient_stats: list,
+    dashboard_base_url: str | None = None,
+) -> str:
     """
     Generate an HTML table of patient summary stats with red highlights for triggered warnings.
 
@@ -242,13 +286,18 @@ def generate_email_body(all_patient_stats: list) -> str:
         has_data_inactive = summary.get(HAS_DATA_WHILE_INACTIVE, False)
         inactive_kw = dict(is_inactive=is_inactive, has_data_inactive=has_data_inactive)
         patient_label = f"{patient} (inactive)" if is_inactive else patient
+        patient_link = _format_patient_label(
+            patient,
+            patient_label,
+            dashboard_base_url,
+        )
 
         if summary.get(MET_09_BUG_DETECTED, False):
             any_met_bug = True
 
         df_rows.append(
             {
-                PT_COLUMN: patient_label,
+                PT_COLUMN: patient_link,
                 # Sleep/rest hours group
                 LASTDAY_SLEEP_COLUMN: style(
                     f"{summary.get(LASTDAY_SLEEP_HOURS, np.nan):.1f}",
@@ -320,7 +369,11 @@ def generate_email_body(all_patient_stats: list) -> str:
 
         survey_rows.append(
             {
-                "Patient": patient,
+                "Patient": _format_patient_label(
+                    patient,
+                    patient,
+                    dashboard_base_url,
+                ),
                 "Activation (ISS)": format_score(iss, "SC1", "ISS"),
                 "Well-being (ISS)": format_score(iss, "SC2", "ISS"),
                 "Perceived Conflict (ISS)": format_score(iss, "SC3", "ISS"),

--- a/trbdv0/send_email.py
+++ b/trbdv0/send_email.py
@@ -186,7 +186,7 @@ def _dashboard_patient_url(dashboard_base_url: str | None, patient: str) -> str 
             "section": "index",
             "environment": "chronic",
             "patient": patient_pk,
-            "tab": "clinical_scores",
+            "tab": "daily_activity",
         }
     )
     separator = "&" if "?" in base_url else "?"

--- a/trbdv0/send_email.py
+++ b/trbdv0/send_email.py
@@ -1,5 +1,6 @@
 import html
 import os
+import re
 import smtplib
 from email.message import EmailMessage
 from email.utils import make_msgid
@@ -177,18 +178,26 @@ def _dashboard_patient_url(dashboard_base_url: str | None, patient: str) -> str 
     if not base_url:
         return None
 
+    patient_pk = _dashboard_patient_pk(patient)
     params = urlencode(
         {
             "mode": "clinical",
             "project": "trbd",
             "section": "index",
             "environment": "chronic",
-            "patient": patient,
+            "patient": patient_pk,
             "tab": "clinical_scores",
         }
     )
     separator = "&" if "?" in base_url else "?"
     return f"{base_url}{separator}{params}"
+
+
+def _dashboard_patient_pk(patient: str) -> str:
+    match = re.search(r"(\d+)$", patient.strip())
+    if match is None:
+        return patient
+    return str(int(match.group(1)))
 
 
 def _format_patient_label(


### PR DESCRIPTION
- Adds optional `dashboard_base_url` config support, with `DASHBOARD_BASE_URL` as an environment fallback.
- Turns TRBD patient names in the wearable summary and survey score tables into dashboard links when configured.
- Uses the dashboard's patient primary key in the URL, so `TRBD002` links to `patient=2` while the email still displays `TRBD002`.
- Opens links on the Daily Activity tab.
- Keeps the email output unchanged when no dashboard URL is set.