### PR TITLE
Do not flag ISS euthymia as warning

### DIFF
--- a/trbdv0/survey_processor.py
+++ b/trbdv0/survey_processor.py
@@ -332,7 +332,6 @@ class ISSProcessor(SurveyProcessor):
         return {
             "(Hypo)Mania": activation >= 155 and well_being >= 125,
             "Mixed State": activation >= 155 and well_being < 125,
-            "Euthymia": activation < 155 and well_being >= 125,
             "Depression": activation < 155 and well_being < 125,
         }
 


### PR DESCRIPTION
- Removes Euthymia from the ISS warning flags.
- Keeps mania, mixed state, and depression warning behavior unchanged.
- Prevents normal Euthymia-range ISS scores from making the daily email look flagged.